### PR TITLE
Fix recipe condition

### DIFF
--- a/src/comps/mini/SimpleFoodCard.jsx
+++ b/src/comps/mini/SimpleFoodCard.jsx
@@ -98,7 +98,7 @@ export default function SimpleFoodCard({
             <p className="text-gray-500">{seedPrice}t</p>
           )}
         </div>
-      ) : type === "fish" || "recipie" ? (
+      ) : type === "fish" || type === "recipe" ? (
         <p className="font-semibold text-gray-800 flex items-center gap-1">
           <BadgeCent className="fill-yellow-100 text-yellow-500 w-5" />
           {sellPrice}t


### PR DESCRIPTION
## Summary
- fix incorrect condition for `recipe` type in `SimpleFoodCard`

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6886ed21c080832b82fac49bf18cc4a6